### PR TITLE
Enhancement AsyncEventDispatcher

### DIFF
--- a/src/imview/include/imview/component/event/async_event_dispatcher.hpp
+++ b/src/imview/include/imview/component/event/async_event_dispatcher.hpp
@@ -31,6 +31,7 @@ class AsyncEventDispatcher {
   void RegisterHandler(const std::string& event_name, HandlerFunc handler);
   void Dispatch(std::shared_ptr<BaseEvent> event);
   void HandleEvents();
+  void Reset();
 
  private:
   AsyncEventDispatcher() = default;

--- a/src/imview/src/component/event/async_event_dispatcher.cpp
+++ b/src/imview/src/component/event/async_event_dispatcher.cpp
@@ -70,4 +70,21 @@ void AsyncEventDispatcher::HandleEvents() {
     }
   }
 }
+
+void AsyncEventDispatcher::Reset() {
+  {
+    std::lock_guard<std::mutex> lock(handler_mutex_);
+    handlers_.clear();
+  }
+
+  // Clear the event queue
+  std::shared_ptr<BaseEvent> event;
+  while (event_queue_.TryPop(event)) {
+    // Pop all events from the queue
+  }
+
+  // Reset thread IDs
+  dispatch_thread_id_ = std::thread::id();
+  handle_events_thread_id_ = std::thread::id();
+}
 }  // namespace quickviz

--- a/src/imview/test/test_async_event.cpp
+++ b/src/imview/test/test_async_event.cpp
@@ -34,7 +34,7 @@ int main(int argc, char* argv[]) {
         auto a = std::get<0>(data);
         auto b = std::get<1>(data);
         auto c = std::get<2>(data);
-        std::cout << "Received event: a = " << a << ", b = " << b
+        std::cout << "Handler 1: Received event: a = " << a << ", b = " << b
                   << ", c = " << c << std::endl;
       });
 
@@ -44,11 +44,98 @@ int main(int argc, char* argv[]) {
   emitter.Emit<Event<int, double, std::string>>(
       EventSource::kApplicaton, "test_event", 21, 6.28, "hello again");
 
-  //  AsyncEventDispatcher::GetInstance().HandleEvents();
-  std::thread handler_thread(&AsyncEventDispatcher::HandleEvents,
-                             &AsyncEventDispatcher::GetInstance());
+  std::cout << std::endl;
 
-  handler_thread.join();
+  // ====================================================================
+  // Test 1: Attempting HandleEvents test without Reset()
+  std::cout << "Test 1: Attempting HandleEvents test without Reset()"
+            << std::endl;
+  std::thread handler_thread_1 =
+      std::thread(&AsyncEventDispatcher::HandleEvents,
+                  &AsyncEventDispatcher::GetInstance());
+  std::cout << "handler_thread_1 id: " << handler_thread_1.get_id()
+            << std::endl;
+  handler_thread_1.join();
+
+  // Create a dummy thread to guarantee that handler thread 2 gets a different
+  // id from handler thread 1
+  std::thread dummy_thread(
+      []() { std::this_thread::sleep_for(std::chrono::milliseconds(100)); });
+
+  // Create another handler thread
+  // Without calling Reset(), this should throw an error
+  std::thread handler_thread_2;
+  handler_thread_2 = std::thread([&]() {
+    try {
+      AsyncEventDispatcher::GetInstance().HandleEvents();
+    } catch (const std::runtime_error& e) {
+      std::cerr << "Caught exception: " << e.what() << std::endl;
+      std::cout << "Note: This exception is expected." << std::endl;
+    }
+  });
+
+  std::cout << "handler_thread_2 id: " << handler_thread_2.get_id()
+            << std::endl;
+  handler_thread_2.join();
+  dummy_thread.join();
+  std::cout << "-----------------------------" << std::endl << std::endl;
+
+  // ====================================================================
+  // Test 2: Attempting HandleEvents test with Reset()
+  std::cout << "Test 2: Attempting HandleEvents test with Reset()" << std::endl;
+
+  // Emit another event
+  emitter.Emit<Event<int, double, std::string>>(
+      EventSource::kApplicaton, "test_event", 101, 1.618, "hello");
+
+  handler_thread_1 = std::thread(&AsyncEventDispatcher::HandleEvents,
+                                 &AsyncEventDispatcher::GetInstance());
+  std::cout << "handler_thread_1 id: " << handler_thread_1.get_id()
+            << std::endl;
+  // Note: AsyncEventDispatcher still has the handler previously registered
+  handler_thread_1.join();
+
+  // Create a dummy thread to guarantee that handler thread 2 gets a different
+  // id from handler thread 1
+  dummy_thread = std::thread(
+      []() { std::this_thread::sleep_for(std::chrono::milliseconds(100)); });
+
+  // This event will not be handled since it was emitted after the
+  // HandleEvents() call and right before the Reset() call
+  emitter.Emit<Event<int, double, std::string>>(
+      EventSource::kApplicaton, "test_ignored_event", 123, 1.618, "bye");
+
+  // Reset the dispatcher
+  // This should clear all handlers, unhandled events and reset any cached
+  // thread ids.
+  AsyncEventDispatcher::GetInstance().Reset();
+
+  // Emit another event. This event will be handled since it was emitted after
+  // the Reset() call
+  emitter.Emit<Event<int, double, std::string>>(
+      EventSource::kApplicaton, "test_event", 102, 1.618, "hello after reset");
+
+  // Reset() clears the handlers, so we need to re-register them
+  AsyncEventDispatcher::GetInstance().RegisterHandler(
+      "test_event", [](std::shared_ptr<BaseEvent> event) {
+        auto data =
+            std::static_pointer_cast<Event<int, double, std::string>>(event)
+                ->GetData();
+        auto a = std::get<0>(data);
+        auto b = std::get<1>(data);
+        auto c = std::get<2>(data);
+        std::cout << "Handler 2: Received event: a = " << a << ", b = " << b
+                  << ", c = " << c << std::endl;
+      });
+
+  // Create another handler thread
+  handler_thread_2 = std::thread(&AsyncEventDispatcher::HandleEvents,
+                                 &AsyncEventDispatcher::GetInstance());
+  std::cout << "handler_thread_2 id: " << handler_thread_2.get_id()
+            << std::endl;
+  handler_thread_2.join();
+  dummy_thread.join();
+  std::cout << "-----------------------------" << std::endl;
 
   return 0;
 }


### PR DESCRIPTION
This PR aims to resolve the issues detailed in #17.

A Reset() functionality was exposed in the AsyncEventDispatcher class. This Reset() method does the following: 

1. Clears all registered handlers. This is useful when stale handlers try to access objects/resources that have been destroyed.
2. Clears the event queue without handling events. If the user wishes to handle all events, HandleEvents() should be called first before Reset().

```
AsyncEventDispatcher::GetInstance().HandleEvents();
AsyncEventDispatcher::GetInstance().Reset();
```

3. Resets all cached thread IDs, so that HandleEvents() can be called from a new thread. This is useful when the executor thread calling HandleEvents() may change throughout the lifetime of the program.