### PR TITLE
build(cmake): sync project VERSION to 0.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if (CCACHE_PROGRAM)
   set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
 endif ()
 
-project(quickviz VERSION 0.6.5)
+project(quickviz VERSION 0.7.0)
 
 message(STATUS "------------------------------------------------")
 if (PROJECT_NAME STREQUAL CMAKE_PROJECT_NAME)


### PR DESCRIPTION
The CMake `project(quickviz VERSION …)` had drifted from the git tags — stuck at **0.6.5** even through the `v0.6.6` release. So the generated `quickvizConfigVersion.cmake` advertises 0.6.5, and with `COMPATIBILITY SameMajorVersion`, `find_package(quickviz 0.7.0)` (or even `0.6.6`) **fails to resolve** — the requested version exceeds the reported one.

Bumps to **0.7.0** to match the just-cut [v0.7.0 release](https://github.com/rxdu/quickviz/releases/tag/v0.7.0), so downstream `find_package(quickviz 0.7.0)` works. Suggest keeping VERSION in lockstep with tags at each release from here.